### PR TITLE
Hardened cibuildwheel cross-compilation and added build preflight.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,21 @@ endif()
 find_package(Python 3.12
   REQUIRED COMPONENTS Interpreter Development.Module)
 
+# When cibuildwheel cross-compiles a Windows ARM64 wheel, the build interpreter is AMD64, so FindPython's Python_SOABI
+# and scikit-build-core's SKBUILD_SOABI both report 'cp3xx-win_amd64'. nanobind derives the extension module's filename
+# suffix from these, mis-naming the module 'cp3xx-win_amd64' even though MSVC emits genuine ARM64 code (the VS generator
+# targets the ARM64 host by default). A module with that suffix is not importable on a real ARM64 interpreter.
+# cibuildwheel passes the correct target suffix via the SETUPTOOLS_EXT_SUFFIX environment variable
+# (e.g. '.cp312-win_arm64.pyd'); the block below derives nanobind's suffix variables from it before nanobind is
+# configured. It is inert for native builds,where SETUPTOOLS_EXT_SUFFIX is unset and the default SOABI already matches
+# the target.
+if (DEFINED ENV{SETUPTOOLS_EXT_SUFFIX})
+  set(NB_SUFFIX "$ENV{SETUPTOOLS_EXT_SUFFIX}")  # Full suffix incl. extension, e.g. '.cp312-win_arm64.pyd'
+  string(REGEX REPLACE "^\\.(.+)\\.pyd$" "\\1" SKBUILD_SOABI "$ENV{SETUPTOOLS_EXT_SUFFIX}")  # -> 'cp312-win_arm64'
+  set(Python_SOABI "${SKBUILD_SOABI}")
+  message(STATUS "Cross-compile suffix override: NB_SUFFIX=${NB_SUFFIX} SOABI=${SKBUILD_SOABI}")
+endif()
+
 # Detects the installed nanobind package and imports it into CMake. The nanobind package itself is installed before
 # the build is executed due to being the building_backend requirement.
 execute_process(

--- a/README.md
+++ b/README.md
@@ -424,9 +424,14 @@ dependencies:
    the required versions.
 2. [Doxygen](https://www.doxygen.nl/manual/install.html), to generate C++ code
    documentation.
-3. An appropriate build tool or Docker, to build binary wheels via
-   [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/). See the link for information on which
-   dependencies to install for each development platform.
+3. A C++ build toolchain and, for cross-architecture wheels, Docker, to build binary wheels via
+   [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/). Testing cross-compiled wheels has
+   per-platform prerequisites: on macOS, Rosetta 2 is required to test x86_64 wheels on Apple Silicon
+   (install it with `softwareupdate --install-rosetta --agree-to-license`); on Linux, non-native
+   architectures build and test inside Docker under QEMU emulation, registered once per machine with
+   `docker run --privileged --rm tonistiigi/binfmt --install all`; on Windows, ARM64 wheels need the
+   ARM64 MSVC runtime, installed through the Visual Studio Installer. Run
+   `python tools/check_build_env.py` to verify these prerequisites before building.
 
 ### Development Automation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,11 +98,20 @@ minimum-version = "0.9"
 # Instructs the backend to use setuptools-style build caching in a local directory
 build-dir = "build/{wheel_tag}"
 
+# Cross-compilation override for Windows ARM64 wheels. cibuildwheel signals the target via the SETUPTOOLS_EXT_SUFFIX
+# environment variable (e.g. '.cp312-win_arm64.pyd'). The Visual Studio CMake generator targets the build host's
+# architecture by default; on a native ARM64 host this is already ARM64, but when cross-building from an AMD64 host
+# (e.g. CI) it would emit AMD64 code. Forcing CMAKE_GENERATOR_PLATFORM=ARM64 guarantees ARM64 binaries regardless of
+# host. The matching module-name fix (NB_SUFFIX / SOABI) lives in CMakeLists.txt.
+[[tool.scikit-build.overrides]]
+if.env.SETUPTOOLS_EXT_SUFFIX = ".*win_arm64.*"
+cmake.define.CMAKE_GENERATOR_PLATFORM = "ARM64"
+
 # Specifies additional configuration for the cibuildwheel backend, which is used to build OS- and Platform-specific
 # binary wheels for the project.
 [tool.cibuildwheel]
 build-verbosity = 1
-skip = ["*t-*"]               # Skip free-threaded wheels
+skip = ["*t-*"]               # Skips free-threaded wheels
 
 # Instructs the frontend to use uv over pip, which significantly improves the build speed.
 build-frontend = "build[uv]"
@@ -113,14 +122,28 @@ build-frontend = "build[uv]"
 test-command = "pytest {project}/tests -n logical --dist loadgroup"
 test-requires = ["pytest", "pytest-xdist"]
 
-# Builds wheels for AMD64 and ARM64 for all platforms and x86 for Linux and Windows.
+# Per-platform architecture matrix: AMD64/ARM64 everywhere, plus x86 on Linux and Windows. The host must be able to
+# cross-compile and emulate these targets; run 'python tools/check_build_env.py' first to confirm readiness up front.
 [tool.cibuildwheel.macos]
+# Testing the x86_64 slice on Apple Silicon requires Rosetta 2 ('softwareupdate --install-rosetta --agree-to-license').
+# arm64 wheels cannot be tested on Intel hosts, where cibuildwheel skips those tests automatically.
 archs = ["x86_64", "arm64"]
 [tool.cibuildwheel.linux]
-# Note. To cross-compile on Linux install this for Docker https://hub.docker.com/r/tonistiigi/binfmt.
+# Non-native architectures build and test inside Docker under QEMU emulation. Register the emulators once per machine
+# with 'docker run --privileged --rm tonistiigi/binfmt --install all'. See https://hub.docker.com/r/tonistiigi/binfmt.
 archs = ["i686", "aarch64", "x86_64"]
 [tool.cibuildwheel.windows]
 archs = ["AMD64", "ARM64", "x86"]
+
+# ARM64-only delvewheel override. The ARM64 MSVC C++ runtime DLLs (msvcp140.dll, vcruntime140*.dll) that the extension
+# links against are NOT on PATH on a Windows host (System32 holds the AMD64 copies), so delvewheel cannot find an
+# architecture-matching DLL to vendor and aborts. The 'tools/repair_windows_wheel.py' helper discovers the ARM64 runtime
+# redistributable directory at build time (via vswhere / VS environment / filesystem glob, with an ATARAXIS_ARM64_CRT_DIR
+# override) and forwards it to delvewheel through '--add-path', so no machine- or version-specific path is hardcoded.
+# Scoped via 'select' so AMD64/x86 Windows wheels keep cibuildwheel's default repair behavior.
+[[tool.cibuildwheel.overrides]]
+select = "*-win_arm64"
+repair-wheel-command = 'python "tools/repair_windows_wheel.py" "{dest_dir}" "{wheel}"'
 
 # Specifies the macOS deployment target, which is needed for full C++17 support (not available in all macOS versions).
 [tool.cibuildwheel.macos.environment]

--- a/tools/check_build_env.py
+++ b/tools/check_build_env.py
@@ -1,0 +1,150 @@
+"""Verifies that the local host is ready to cross-build and test the configured binary wheels before cibuildwheel runs.
+
+cibuildwheel cross-compiles wheels for several architectures per platform, but testing a foreign-architecture wheel
+needs emulation that cibuildwheel does not install. When the emulation layer is missing, the build proceeds and then
+fails deep in the test phase with an opaque error. This preflight reads the architecture matrix from ``pyproject.toml``
+and checks the host up front, failing fast with concrete remediation instead.
+
+On macOS it confirms Rosetta 2 is present when x86_64 wheels are tested on Apple Silicon, and warns that arm64 wheels
+cannot be tested on Intel hosts. On Linux it confirms Docker is running and that QEMU is registered with binfmt_misc for
+every non-native architecture. On Windows it confirms the ARM64 MSVC runtime redistributable resolves when ARM64 wheels
+are configured, reusing the same discovery the repair step depends on.
+
+The script is intentionally dependency-free so it can run inside the thin tox build environment, which does not install
+the project or its runtime dependencies. It reports problems on standard error and exits non-zero, mirroring the repair
+helper alongside it.
+"""
+
+from __future__ import annotations
+
+import sys
+import shutil
+import platform
+import tomllib
+import subprocess
+from pathlib import Path
+
+from repair_windows_wheel import discover_crt_dir
+
+_PYPROJECT: Path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+"""Location of the project configuration that declares the per-platform architecture build matrix."""
+
+_QEMU_BY_ARCH: dict[str, str] = {
+    "aarch64": "qemu-aarch64",
+    "x86_64": "qemu-x86_64",
+    "i686": "qemu-i386",
+    "ppc64le": "qemu-ppc64le",
+    "s390x": "qemu-s390x",
+}
+"""Maps a cibuildwheel Linux architecture to the binfmt_misc handler name QEMU registers for it."""
+
+_NATIVE_LINUX_ARCHS: dict[str, frozenset[str]] = {
+    "x86_64": frozenset({"x86_64", "i686"}),
+    "aarch64": frozenset({"aarch64"}),
+}
+"""Maps a Linux host machine to the target architectures it executes natively, without QEMU emulation."""
+
+
+def main() -> int:
+    """Checks host readiness for the current platform and reports problems before cibuildwheel runs."""
+    host = sys.platform
+    if host == "darwin":
+        errors, warnings = _check_macos()
+    elif host.startswith("linux"):
+        errors, warnings = _check_linux()
+    elif host == "win32":
+        errors, warnings = _check_windows()
+    else:
+        message = f"Unable to verify the build environment. The host platform '{host}' is not supported."
+        raise SystemExit(message)
+
+    for warning in warnings:
+        sys.stdout.write(f"WARNING: {warning}\n")
+    if errors:
+        report = "\n".join(f"  - {error}" for error in errors)
+        message = f"The build environment is not ready. Resolve the following before running cibuildwheel:\n{report}"
+        raise SystemExit(message)
+    sys.stdout.write("The build environment is ready for cibuildwheel.\n")
+    return 0
+
+
+def _check_macos() -> tuple[list[str], list[str]]:
+    """Checks whether macOS can test every configured wheel architecture, given Rosetta 2 emulation constraints."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    host_arch = platform.machine()
+    archs = _read_archs(platform_key="macos") or [host_arch]
+
+    if host_arch == "arm64" and "x86_64" in archs:
+        # cibuildwheel runs the x86_64 test suite under Rosetta 2; without it the test phase fails.
+        probe = subprocess.run(["arch", "-x86_64", "/usr/bin/true"], capture_output=True, check=False)
+        if probe.returncode != 0:
+            errors.append(
+                "Rosetta 2 is required to test x86_64 wheels on Apple Silicon but is not installed. Install it with "
+                "'softwareupdate --install-rosetta --agree-to-license'."
+            )
+    if host_arch == "x86_64" and "arm64" in archs:
+        warnings.append(
+            "arm64 wheels cannot be tested on an Intel host; cibuildwheel will skip those tests. Set "
+            "CIBW_TEST_SKIP='*_arm64 *_universal2:arm64' to silence the warning."
+        )
+    return errors, warnings
+
+
+def _check_linux() -> tuple[list[str], list[str]]:
+    """Checks whether Docker is running and QEMU is registered for every non-native architecture to build."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if shutil.which("docker") is None:
+        errors.append("Docker is required to build Linux wheels but the 'docker' command was not found on PATH.")
+        return errors, warnings
+    probe = subprocess.run(["docker", "info"], capture_output=True, check=False)
+    if probe.returncode != 0:
+        errors.append("Docker is installed but not responding. Start the Docker daemon and try again.")
+        return errors, warnings
+
+    host_arch = platform.machine()
+    native = _NATIVE_LINUX_ARCHS.get(host_arch, frozenset({host_arch}))
+    emulated = [arch for arch in (_read_archs(platform_key="linux") or [host_arch]) if arch not in native]
+    missing = sorted(arch for arch in emulated if not _binfmt_registered(arch=arch))
+    if missing:
+        targets = ", ".join(missing)
+        errors.append(
+            f"QEMU emulation is not registered for {targets}, which Docker needs to build these architectures. "
+            f"Register it with 'docker run --privileged --rm tonistiigi/binfmt --install all'."
+        )
+    return errors, warnings
+
+
+def _check_windows() -> tuple[list[str], list[str]]:
+    """Checks whether the ARM64 MSVC runtime resolves when ARM64 wheels are part of the build matrix."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    if "ARM64" in _read_archs(platform_key="windows") and discover_crt_dir(arch="arm64") is None:
+        errors.append(
+            "The ARM64 MSVC C++ runtime redistributable could not be located, which delvewheel needs to repair ARM64 "
+            "wheels. Install the ARM64 build tools and the C++ ARM64 runtime via the Visual Studio Installer."
+        )
+    return errors, warnings
+
+
+def _read_archs(platform_key: str) -> list[str]:
+    """Returns the architectures configured for the given cibuildwheel platform, or an empty list when none are set."""
+    with _PYPROJECT.open("rb") as handle:
+        config = tomllib.load(handle)
+    platform_table = config.get("tool", {}).get("cibuildwheel", {}).get(platform_key, {})
+    return list(platform_table.get("archs", []))
+
+
+def _binfmt_registered(arch: str) -> bool:
+    """Returns True when binfmt_misc has an enabled QEMU handler registered for the given architecture."""
+    handler = _QEMU_BY_ARCH.get(arch)
+    if handler is None:
+        return False
+    handler_path = Path("/proc/sys/fs/binfmt_misc") / handler
+    return handler_path.is_file() and "enabled" in handler_path.read_text(encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/repair_windows_wheel.py
+++ b/tools/repair_windows_wheel.py
@@ -1,0 +1,151 @@
+"""Repairs a freshly built Windows wheel with delvewheel, auto-discovering the MSVC C++ runtime redistributable.
+
+Supports Windows ARM64 wheels built by cibuildwheel. The compiled extension links against the MSVC C++ runtime
+(``msvcp140.dll``, ``vcruntime140*.dll``). On a typical Windows host only the AMD64 copies of these DLLs are present on
+``PATH`` (under ``System32``); the ARM64 copies ship only inside the Visual Studio redistributable tree, which is not on
+``PATH``. delvewheel therefore cannot find an architecture-matching runtime to vendor and aborts. Rather than hardcode a
+machine- and version-specific redistributable path in ``pyproject.toml``, this script discovers the correct directory at
+build time and passes it to delvewheel via ``--add-path``.
+
+The resolver adapts to local build infrastructure through a layered fallback chain. It first honors an explicit
+``ATARAXIS_ARM64_CRT_DIR`` override, then the ``VCToolsRedistDir`` variable set inside a Visual Studio developer command
+prompt. Then it queries ``vswhere.exe`` (installed at a stable Microsoft-guaranteed path) and reads the
+``Microsoft.VCRedistVersion.default.txt`` marker for the default redistributable version, and finally globs every
+Program Files Visual Studio installation for the newest redistributable. For non-ARM64 wheels it simply forwards to
+delvewheel without an extra search path, preserving the default repair behavior for AMD64 and x86 builds.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import glob
+import subprocess
+from pathlib import Path
+
+_VSWHERE: Path = (
+    Path(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"))
+    / "Microsoft Visual Studio"
+    / "Installer"
+    / "vswhere.exe"
+)
+"""Stable, Microsoft-guaranteed location of the Visual Studio locator utility, present for any modern installation."""
+
+_ARCH_BY_TAG: dict[str, str] = {"win_arm64": "arm64", "win_amd64": "x64", "win32": "x86"}
+"""Maps the wheel-filename platform tag to the Visual Studio redistributable architecture subdirectory name."""
+
+
+def main() -> int:
+    """Resolves the runtime directory for ARM64 targets and runs delvewheel to repair the wheel."""
+    if len(sys.argv) != 3:
+        message = (
+            f"Unable to repair a Windows wheel using {Path(sys.argv[0]).name}. The script requires exactly two "
+            f"positional arguments, the destination directory and the wheel path, but received {len(sys.argv) - 1}."
+        )
+        raise SystemExit(message)
+    dest_dir, wheel = sys.argv[1], sys.argv[2]
+
+    command = [sys.executable, "-m", "delvewheel", "repair", "-v", "-w", dest_dir, wheel]
+
+    tag = next((candidate for candidate in _ARCH_BY_TAG if candidate in Path(wheel).name), None)
+    # Only ARM64 needs an explicit search path; AMD64 and x86 runtimes are already on the host's PATH.
+    if tag == "win_arm64":
+        crt_dir = discover_crt_dir(arch=_ARCH_BY_TAG[tag])
+        if crt_dir is None:
+            message = (
+                f"Unable to repair the ARM64 wheel '{Path(wheel).name}'. Could not locate the ARM64 MSVC C++ runtime "
+                f"redistributable (a 'Microsoft.VC*.CRT' folder containing 'msvcp140.dll'). Install the ARM64 build "
+                f"tools and the C++ ARM64 runtime via the Visual Studio Installer, or set ATARAXIS_ARM64_CRT_DIR to "
+                f"the redistributable directory."
+            )
+            raise FileNotFoundError(message)
+        sys.stdout.write(f"Using ARM64 MSVC runtime redistributable: {crt_dir}\n")
+        command += ["--add-path", str(crt_dir)]
+
+    sys.stdout.flush()
+    return subprocess.run(command, check=False).returncode
+
+
+def discover_crt_dir(arch: str) -> Path | None:
+    """Discovers the MSVC runtime redistributable directory for the requested architecture via the fallback chain."""
+    # Honor an explicit manual override before probing the toolchain.
+    override = os.environ.get("ATARAXIS_ARM64_CRT_DIR")
+    if override and (Path(override) / "msvcp140.dll").is_file():
+        return Path(override)
+
+    # Fall back to the developer-prompt variable, which points at the redistributable version root.
+    redist_root = os.environ.get("VCToolsRedistDir")
+    if redist_root:
+        for candidate in sorted((Path(redist_root) / arch).glob("Microsoft.VC*.CRT")):
+            if (candidate / "msvcp140.dll").is_file():
+                return candidate
+
+    # Query vswhere for the active Visual Studio installation(s) and resolve each one's redistributable.
+    if _VSWHERE.is_file():
+        result = subprocess.run(
+            [str(_VSWHERE), "-products", "*", "-latest", "-prerelease", "-property", "installationPath"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        for line in result.stdout.splitlines():
+            install_path = Path(line.strip())
+            if install_path.is_dir():
+                crt_dir = _crt_dir_for(install_path=install_path, arch=arch)
+                if crt_dir is not None:
+                    return crt_dir
+
+    # Glob every Program Files Visual Studio installation as a last resort; the newest version wins.
+    program_files = {
+        os.environ.get("ProgramFiles", r"C:\Program Files"),
+        os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),
+    }
+    matches: list[str] = []
+    for root in filter(None, program_files):
+        pattern = str(
+            Path(root)
+            / "Microsoft Visual Studio"
+            / "*"
+            / "*"
+            / "VC"
+            / "Redist"
+            / "MSVC"
+            / "*"
+            / arch
+            / "Microsoft.VC*.CRT"
+        )
+        matches.extend(path for path in glob.glob(pattern) if (Path(path) / "msvcp140.dll").is_file())
+    return Path(max(matches, key=_version_key)) if matches else None
+
+
+def _crt_dir_for(install_path: Path, arch: str) -> Path | None:
+    """Returns the runtime redistributable directory for the given architecture within a Visual Studio installation.
+
+    Reads the ``Microsoft.VCRedistVersion.default.txt`` marker to determine the default redistributable version, then
+    resolves the ``Microsoft.VC*.CRT`` folder that actually contains ``msvcp140.dll``. Returns None when the marker or
+    the runtime folder is absent.
+    """
+    marker = install_path / "VC" / "Auxiliary" / "Build" / "Microsoft.VCRedistVersion.default.txt"
+    if not marker.is_file():
+        return None
+    version = marker.read_text(encoding="utf-8").strip()
+    arch_root = install_path / "VC" / "Redist" / "MSVC" / version / arch
+    for candidate in sorted(arch_root.glob("Microsoft.VC*.CRT")):
+        if (candidate / "msvcp140.dll").is_file():
+            return candidate
+    return None
+
+
+def _version_key(path: str) -> tuple[int, ...]:
+    """Builds a sortable numeric key from the MSVC version segment embedded in a redistributable path.
+
+    Allows '14.44.35112' to sort above '14.29.30133' numerically rather than lexicographically. Non-numeric or missing
+    segments collapse to a zero key so such paths sort last.
+    """
+    match = re.search(pattern=r"\\Redist\\MSVC\\([0-9.]+)\\", string=path)
+    return tuple(int(part) for part in match.group(1).split(".")) if match else (0,)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,7 @@ description =
 deps = ataraxis-automation==8.1.1
 allowlist_externals = docker
 commands =
+    python tools/check_build_env.py
     python -m build . --sdist
     cibuildwheel --output-dir dist --platform auto
 


### PR DESCRIPTION
-- Fixed Windows ARM64 cross-compilation by deriving nanobind's module suffix from SETUPTOOLS_EXT_SUFFIX and forcing the ARM64 generator platform. -- Added tools/repair_windows_wheel.py to dynamically resolve the ARM64 MSVC runtime for delvewheel instead of hardcoding a path. -- Added tools/check_build_env.py to preflight macOS Rosetta 2, Linux Docker and QEMU, and the Windows ARM64 runtime before building. -- Wired the build preflight into the tox build environment as its first step. -- Documented the per-platform cross-compilation prerequisites in pyproject.toml and the README.